### PR TITLE
Fix trailing comma for IE 7 compatibility

### DIFF
--- a/collective/easyslider/browser/files/easySlider.js
+++ b/collective/easyslider/browser/files/easySlider.js
@@ -38,7 +38,7 @@ $.fn.randomize = function(childElem) {
       navigation_buttons_rendering_type : 'standard',
       resume_play : false,
       randomize: false,
-      hoverPause: true, 
+      hoverPause: true
     }; 
     
     var options = $.extend(defaults, options);  

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-version = '1.0'
+version = '1.0-dev'
 
 setup(name='collective.easyslider',
       version=version,


### PR DESCRIPTION
Remove trailing comma which restores compatibility with older versions of IE
