### PR TITLE
workaround for  view/navigation_type

### DIFF
--- a/collective/easyslider/browser/viewlet.py
+++ b/collective/easyslider/browser/viewlet.py
@@ -53,9 +53,10 @@ class BaseSliderViewlet(ViewletBase):
 class EasySlider(BaseSliderViewlet):
 
     def navigation_type(self):
-        settings = ViewSliderSettings(self.context)
-        return settings.navigation_type.lower().replace(' ', '-')
-
+    	settings = ViewSliderSettings(self.context)
+    	return settings.navigation_type.lower().replace(' ', '-')
+ 		
+		
     def transform(self, text, mt='text/x-html-safe'):
         """
         Code from plone.portlet.static with adaptions

--- a/collective/easyslider/browser/viewlet_below.pt
+++ b/collective/easyslider/browser/viewlet_below.pt
@@ -1,8 +1,10 @@
-<tal:show tal:define="show view/show; 
-		  sliderposition view/sliderposition;
-		  uid context/UID|string:nouid;"
-		  tal:condition="python: show and sliderposition==1">
-  <div id="slider-container" tal:attributes="class string:slider-${uid} slider-navtype-below" tal:define="slides view/slides" i18n:domain="collective.easyslider">
+<tal:show tal:define="show python: view.show; 
+		  sliderposition python: view.sliderposition;
+		  uid context/UID|string:nouid;
+		  navtype python: view.navigation_type;"
+		  tal:condition="python: show and sliderposition">
+  <div id="slider-container" tal:attributes="class string:slider-${uid} slider-navtype-${navtype};" 
+  	    tal:define="slides view/slides" i18n:domain="collective.easyslider">
     <div id="slider" 
          tal:attributes="class string:slider-${uid}" 
          i18n:attributes="data-next_picture_alt next_picture_alt;


### PR DESCRIPTION
This was not working when adding portlets, giving:

TypeError: ('Could not adapt', <PortletAssignmentMapping at /Plonesite/page/++contextportlets++plone.leftcolumn>, <InterfaceClass zope.annotation.interfaces.IAnnotations>)
