### PR TITLE
setup.py : conditional import of plone.z3cform for Plone >= 4.3

### DIFF
--- a/collective/easyslider/tests/test_doctests.py
+++ b/collective/easyslider/tests/test_doctests.py
@@ -1,4 +1,8 @@
-import unittest2 as unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
 from Testing import ZopeTestCase as ztc
 from collective.easyslider.tests import BaseFunctionalTest
 

--- a/collective/easyslider/tests/test_setup.py
+++ b/collective/easyslider/tests/test_setup.py
@@ -1,4 +1,8 @@
-import unittest2 as unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
 from collective.easyslider.tests import BaseTest
 from zope.component import getUtilitiesFor, queryUtility
 from plone.portlets.interfaces import IPortletType

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ try:
     # Plone < 4.3
     import plone.app.z3cform
     install_requires.append('plone.app.z3cform')
-except:
+except ImportError:
     # Plone >= 4.3
     install_requires.append('plone.z3cform')
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,17 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 import os
+
+install_requires = [
+    'setuptools',
+]
+
+try:
+    # Plone < 4.3
+    import plone.app.z3cform
+    install_requires.append('plone.app.z3cform')
+except:
+    # Plone >= 4.3
+    install_requires.append('plone.z3cform')
 
 version = '1.4.2'
 
@@ -37,10 +49,7 @@ setup(name='collective.easyslider',
               'plone.app.testing',
           ]
       },
-      install_requires=[
-          'setuptools',
-          'plone.app.z3cform'
-      ],
+      install_requires=install_requires,
       entry_points="""
       # -*- Entry points: -*-
 


### PR DESCRIPTION
Hello,

I was trying to upgrade a Plone site from 4.2.6 to 4.3.15, and it looks like plone.app.z3cform has been renamed to plone.z3cform (without .app). A cursory glance at the two modules seems to show an identical, or very similar, content, so I think it's safe to solve the compatibility issue by just a conditional dependency in the setup.py file.

Laurent.
